### PR TITLE
Update coverage scripts.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-service-core ChangeLog
 
+## 3.1.0 - 2022-03-TBD
+
+### Added
+- Add missing peer dependencies `bedrock-jsonld-document-loader@1.22`,
+  `bedrock-meter-usage-reporter@5.1` and `bedrock-veres-one-context@12.0`.
+- Add missing dependency `@digitalbazaar/ed25519-signature-2020` in test.
+
 ## 3.0.0 - 2022-03-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -41,9 +41,12 @@
     "bedrock-did-context": "^2.0.3",
     "bedrock-did-io": "^6.0.2",
     "bedrock-express": "^6.2.2",
+    "bedrock-jsonld-document-loader": "^1.2.2",
+    "bedrock-meter-usage-reporter": "5.1.0",
     "bedrock-mongodb": "^8.4.0",
     "bedrock-security-context": "^5.0.0",
     "bedrock-validation": "^5.5.0",
+    "bedrock-veres-one-context": "12.0.0",
     "bedrock-zcap-storage": "^5.0.0"
   },
   "directories": {

--- a/test/package.json
+++ b/test/package.json
@@ -9,6 +9,7 @@
     "coverage-report": "nyc report"
   },
   "dependencies": {
+    "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/ezcap": "^2.0.2",
     "@digitalbazaar/http-client": "^2.0.1",
     "@digitalbazaar/webkms-client": "^10.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
-    "coverage": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcov --reporter=text-summary npm test",
-    "coverage-ci": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcovonly npm test",
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
-    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
-    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
+    "coverage": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test ESM_OPTIONS='{cache:false}' nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {


### PR DESCRIPTION
Note: `codecov-action@v1` has been deprecrated https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1, so I've updated it to v2.