### PR TITLE
Support ipv6 in ipAllowList.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - `@bedrock/zcap-storage@8`
 - Lint module.
 
+### Added
+- Support IPv6 CIDRs in `ipAllowList`.
+  - Switching from `netmask` to `ipaddr.js` to support IPv6.
+
 ## 5.1.0 - 2022-05-13
 
 ### Added

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,7 @@
 import * as bedrock from '@bedrock/core';
 import assert from 'assert-plus';
 import forwarded from 'forwarded';
-import {Netmask} from 'netmask';
+import ipaddr from 'ipaddr.js';
 import {generateId, decodeId} from 'bnid';
 
 // get a fully qualified service object ID from a `service` and `req` OR
@@ -68,6 +68,7 @@ export function decodeLocalId({localId} = {}) {
 }
 
 export function verifyRequestIp({config, req}) {
+  // skip check if no IP allow list configured
   const {ipAllowList} = config;
   if(!ipAllowList) {
     return {verified: true};
@@ -78,15 +79,17 @@ export function verifyRequestIp({config, req}) {
   // IPs will be from the `x-forwarded-for` header.
   const sourceAddresses = forwarded(req);
 
-  // ipAllowList is an array of CIDRs
-  for(const cidr of ipAllowList) {
-    const netmask = new Netmask(cidr);
-    for(const address of sourceAddresses) {
-      if(netmask.contains(address)) {
-        return {verified: true};
-      }
-    }
-  }
+  // build list of allowed IP ranges from IPv4/IPv6 CIDRs
+  const ipAllowRangeList = {
+    allow: ipAllowList.map(cidr => ipaddr.parseCIDR(cidr))
+  };
 
-  return {verified: false};
+  // check if any source address allowed
+  const verified = sourceAddresses.some(address => {
+    const ip = ipaddr.parse(address);
+    // check if in allow list, else deny
+    return ipaddr.subnetMatch(ip, ipAllowRangeList, 'deny') === 'allow';
+  });
+
+  return {verified};
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "cors": "^2.8.5",
     "crypto-ld": "^7.0.0",
     "forwarded": "^0.2.0",
-    "klona": "^2.0.5",
-    "netmask": "^2.0.2"
+    "ipaddr.js": "^2.0.1",
+    "klona": "^2.0.5"
   },
   "peerDependencies": {
     "@bedrock/core": "^6.0.1",

--- a/schemas/bedrock-service-core.js
+++ b/schemas/bedrock-service-core.js
@@ -19,7 +19,7 @@ const ipAllowList = {
   items: {
     type: 'string',
     // leading and trailing slashes in regex must be removed
-    pattern: cidrRegex.v4({exact: true}).toString().slice(1, -1),
+    pattern: cidrRegex({exact: true}).toString().slice(1, -1),
   }
 };
 

--- a/test/mocha/10-http.js
+++ b/test/mocha/10-http.js
@@ -34,7 +34,7 @@ describe('bedrock-service-core HTTP API', () => {
         result.controller.should.equal(capabilityAgentId);
       });
       it('creates a config including proper ipAllowList', async () => {
-        const ipAllowList = ['127.0.0.1/32'];
+        const ipAllowList = ['127.0.0.1/32', '::1/128'];
 
         let err;
         let result;
@@ -128,7 +128,7 @@ describe('bedrock-service-core HTTP API', () => {
         result.id.should.equal(config.id);
       });
       it('gets a config with ipAllowList', async () => {
-        const ipAllowList = ['127.0.0.1/32'];
+        const ipAllowList = ['127.0.0.1/32', '::1/128'];
 
         const config = await helpers.createConfig(
           {capabilityAgent, ipAllowList});
@@ -343,7 +343,7 @@ describe('bedrock-service-core HTTP API', () => {
           const capabilityAgent2 = await CapabilityAgent.fromSecret(
             {secret: 's2', handle: 'h2'});
 
-          const ipAllowList = ['127.0.0.1/32'];
+          const ipAllowList = ['127.0.0.1/32', '::1/128'];
 
           let err;
           let result;


### PR DESCRIPTION
- Switching from `netmask` to `ipaddr.js` to support IPv6.
- Change schema to allow IPv4 or IPv6 CDIR values.
- Update localhost tests to have both IPv4 and IPv6 CIDR.

This is needed to support, at least, Node.js 18 GitHub actions testing.  It was returning `::1` as an address and the `netmask` library does not support IPv6.

For review:
- I don't know how this `ipAllowList` is used at higher levels, so unsure how to test beyond the tests here.
- Is performance here critical?  The main `ipaddr.js` call is using a parsed structure that could be computed once.  I'm not sure where that should go though.