### PR TITLE
Add a note about commented out `allowedAlgorithms` in config.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,7 @@ cfg.authorization = {
   oauth2: {
     // 300 second clock skew permitted by default
     maxClockSkew: 300,
+    // note: allowedAlgorithms must be set by the top-level/parent app.
     /*allowedAlgorithms: [
       // RSASSA-PKCS1-v1_ w/sha-XXX
       'RS256',


### PR DESCRIPTION
Should `allowedAlgorithms` in config be uncommented? I'm getting `allowedAlgorithms` undefined here  https://github.com/digitalbazaar/bedrock-oauth2-verifier/blob/main/lib/index.js#L84 when trying to issue credentials using `oauth2-authorized` issuer instance. Or is this meant to be set by the parent app - issuer/verifier?